### PR TITLE
Better errors

### DIFF
--- a/lib/property_test.ex
+++ b/lib/property_test.ex
@@ -5,38 +5,10 @@ defmodule PropertyTest do
   TODO: better overview of property testing and shrinking.
   """
 
+  alias ExUnit.AssertionError
+
   defmodule Error do
     defexception [:message]
-
-    def exception(test_result) when is_map(test_result) do
-      %__MODULE__{message: format_message(test_result)}
-    end
-
-    defp format_message(%{original_failure: original_failure, shrunk_failure: shrunk_failure, nodes_visited: nodes_visited}) do
-      formatted_original = indent(Exception.format(:error, original_failure.exception, original_failure.stacktrace))
-      formatted_shrunk = indent(Exception.format(:error, shrunk_failure.exception, shrunk_failure.stacktrace))
-      formatted_values = "  " <> Enum.map_join(shrunk_failure.generated_values, "\n\n  ", fn {gen_string, value} ->
-        gen_string <> "\n  #=> " <> inspect(value)
-      end)
-
-      """
-      property failed. Original failure:
-
-      #{formatted_original}
-
-      Failure from shrunk data:
-
-      #{formatted_shrunk}
-
-      Shrunk generated values:
-
-      #{formatted_values}
-
-      (visited a total of #{nodes_visited} nodes)
-      """
-    end
-
-    defp indent(string), do: "  " <> String.replace(string, "\n", "\n" <> "  ")
   end
 
   @doc """
@@ -167,13 +139,17 @@ defmodule PropertyTest do
 
       property =
         StreamData.gen all unquote_splicing(clauses) do
-          generated_values = var!(generated_values, StreamData)
           fn ->
             try do
               unquote(body)
             rescue
               exception ->
-                {:error, %{exception: exception, stacktrace: System.stacktrace(), generated_values: generated_values}}
+                result = %{
+                  exception: exception,
+                  stacktrace: System.stacktrace(),
+                  generated_values: var!(generated_values, StreamData),
+                }
+                {:error, result}
             else
               _result ->
                 {:ok, nil}
@@ -191,9 +167,48 @@ defmodule PropertyTest do
       case StreamData.check_all(property, options, &(&1.())) do
         {:ok, _result} ->
           :ok
-        {:error, result} ->
-          raise Error, result
+        {:error, test_result} ->
+          PropertyTest.__raise__(test_result)
       end
     end
   end
+
+  def __raise__(test_result) do
+    %{original_failure: original_failure,
+      shrunk_failure: shrunk_failure,
+      nodes_visited: nodes_visited} = test_result
+    choose_error_and_raise(original_failure, shrunk_failure, nodes_visited)
+  end
+
+  defp choose_error_and_raise(_, %{exception: %AssertionError{}} = shrunk_failure, nodes_visited) do
+    reraise enrich_assertion_error(shrunk_failure, nodes_visited), shrunk_failure.stacktrace
+  end
+
+  defp choose_error_and_raise(%{exception: %AssertionError{}} = original_failure, _, nodes_visited) do
+    reraise enrich_assertion_error(original_failure, nodes_visited), original_failure.stacktrace
+  end
+
+  defp choose_error_and_raise(_original_failure, shrunk_failure, _nodes_visited) do
+    formatted = indent(Exception.format(:error, shrunk_failure.exception, shrunk_failure.stacktrace))
+    message = "failed with generated values:\n\n#{format_generated_values(shrunk_failure.generated_values)}\n\n#{formatted}"
+    raise Error, message: message
+  end
+
+  defp enrich_assertion_error(%{exception: exception, generated_values: generated_values}, _nodes_visited) do
+    message =
+      "Failed with generated values:\n\n#{format_generated_values(generated_values)}" <>
+      if(is_binary(exception.message), do: "\n\n" <> exception.message, else: "")
+
+    %{exception | message: message}
+  end
+
+  defp format_generated_values(values) do
+    formatted =
+      Enum.map_join(values, "\n\n  ", fn {gen_string, value} ->
+        gen_string <> "\n  #=> " <> inspect(value)
+      end)
+    "  " <> formatted
+  end
+
+  defp indent(string), do: "  " <> String.replace(string, "\n", "\n" <> "  ")
 end

--- a/lib/property_test.ex
+++ b/lib/property_test.ex
@@ -188,15 +188,19 @@ defmodule PropertyTest do
     reraise enrich_assertion_error(original_failure, nodes_visited), original_failure.stacktrace
   end
 
-  defp choose_error_and_raise(_original_failure, shrunk_failure, _nodes_visited) do
+  defp choose_error_and_raise(_original_failure, shrunk_failure, nodes_visited) do
     formatted = indent(Exception.format_banner(:error, shrunk_failure.exception, shrunk_failure.stacktrace))
-    message = "failed with generated values:\n\n#{format_generated_values(shrunk_failure.generated_values)}\n\n#{formatted}"
+    message =
+      "failed with generated values (after #{nodes_visited} attempt(s)):\n\n" <>
+      "#{format_generated_values(shrunk_failure.generated_values)}\n\n" <>
+      formatted
     reraise Error, [message: message], shrunk_failure.stacktrace
   end
 
-  defp enrich_assertion_error(%{exception: exception, generated_values: generated_values}, _nodes_visited) do
+  defp enrich_assertion_error(%{exception: exception, generated_values: generated_values}, nodes_visited) do
     message =
-      "Failed with generated values:\n\n#{format_generated_values(generated_values)}" <>
+      "Failed with generated values (after #{nodes_visited} attempt(s)):\n\n" <>
+      format_generated_values(generated_values) <>
       if(is_binary(exception.message), do: "\n\n" <> exception.message, else: "")
 
     %{exception | message: message}

--- a/lib/property_test.ex
+++ b/lib/property_test.ex
@@ -189,9 +189,9 @@ defmodule PropertyTest do
   end
 
   defp choose_error_and_raise(_original_failure, shrunk_failure, _nodes_visited) do
-    formatted = indent(Exception.format(:error, shrunk_failure.exception, shrunk_failure.stacktrace))
+    formatted = indent(Exception.format_banner(:error, shrunk_failure.exception, shrunk_failure.stacktrace))
     message = "failed with generated values:\n\n#{format_generated_values(shrunk_failure.generated_values)}\n\n#{formatted}"
-    raise Error, message: message
+    reraise Error, [message: message], shrunk_failure.stacktrace
   end
 
   defp enrich_assertion_error(%{exception: exception, generated_values: generated_values}, _nodes_visited) do

--- a/lib/property_test.ex
+++ b/lib/property_test.ex
@@ -189,10 +189,10 @@ defmodule PropertyTest do
   end
 
   defp choose_error_and_raise(_original_failure, shrunk_failure, nodes_visited) do
-    formatted = indent(Exception.format_banner(:error, shrunk_failure.exception, shrunk_failure.stacktrace))
+    formatted = indent(Exception.format_banner(:error, shrunk_failure.exception, shrunk_failure.stacktrace), "  ")
     message =
       "failed with generated values (after #{nodes_visited} attempt(s)):\n\n" <>
-      "#{format_generated_values(shrunk_failure.generated_values)}\n\n" <>
+      "#{indent(format_generated_values(shrunk_failure.generated_values), "    ")}\n\n" <>
       formatted
     reraise Error, [message: message], shrunk_failure.stacktrace
   end
@@ -200,19 +200,19 @@ defmodule PropertyTest do
   defp enrich_assertion_error(%{exception: exception, generated_values: generated_values}, nodes_visited) do
     message =
       "Failed with generated values (after #{nodes_visited} attempt(s)):\n\n" <>
-      format_generated_values(generated_values) <>
+      indent(format_generated_values(generated_values), "    ") <>
       if(is_binary(exception.message), do: "\n\n" <> exception.message, else: "")
 
     %{exception | message: message}
   end
 
   defp format_generated_values(values) do
-    formatted =
-      Enum.map_join(values, "\n\n  ", fn {gen_string, value} ->
-        gen_string <> "\n  #=> " <> inspect(value)
-      end)
-    "  " <> formatted
+    Enum.map_join(values, "\n\n", fn {gen_string, value} ->
+      gen_string <> "\n#=> " <> inspect(value)
+    end)
   end
 
-  defp indent(string), do: "  " <> String.replace(string, "\n", "\n" <> "  ")
+  defp indent(string, indentation) do
+    indentation <> String.replace(string, "\n", "\n" <> indentation)
+  end
 end

--- a/lib/stream_data.ex
+++ b/lib/stream_data.ex
@@ -1536,7 +1536,7 @@ defmodule StreamData do
 
   defp compile_clauses([], body) do
     quote do
-      generated_values = Enum.reverse(var!(generated_values, unquote(__MODULE__)))
+      var!(generated_values, unquote(__MODULE__)) = Enum.reverse(var!(generated_values, unquote(__MODULE__)))
       {:cont, StreamData.constant(unquote(body))}
     end
   end


### PR DESCRIPTION
Addresses #6.

Errors look like this:

<details>

```
  1) property something with filter (StdlibSamplesTest)
     examples/examples_test.exs:23
     Failed with generated values:
     
       a <- int()
       #=> 0
     
       b <- int()
       #=> 0
     
     Assertion with > failed, both sides are exactly equal
     code: assert sum > 0
     left: 0
     stacktrace:
       examples/examples_test.exs:28: anonymous fn/2 in StdlibSamplesTest."property something with filter"/1
       (stream_data) lib/stream_data.ex:1420: StreamData.check_all/6
       examples/examples_test.exs:24: (test)



  2) test non-assertion error (StdlibSamplesTest)
     examples/examples_test.exs:32
     ** (PropertyTest.Error) failed with generated values:
     
       tuple <- {:ok, int()}
       #=> {:ok, 0}
     
       ** (MatchError) no match of right hand side value: {:ok, 0}
           examples/examples_test.exs:40: StdlibSamplesTest.failing_tuple_match/1
           examples/examples_test.exs:35: anonymous fn/2 in StdlibSamplesTest."test non-assertion error"/1
           (stream_data) lib/stream_data.ex:1454: StreamData.shrink_failure/6
           (stream_data) lib/stream_data.ex:1424: StreamData.check_all/6
           examples/examples_test.exs:34: StdlibSamplesTest."test non-assertion error"/1
           (ex_unit) lib/ex_unit/runner.ex:292: ExUnit.Runner.exec_test/1
           (stdlib) timer.erl:166: :timer.tc/1
           (ex_unit) lib/ex_unit/runner.ex:240: anonymous fn/3 in ExUnit.Runner.spawn_test/3
       
     code: check all tuple <- {:ok, int()} do
     stacktrace:
       (stream_data) lib/property_test.ex:194: PropertyTest.choose_error_and_raise/3
       examples/examples_test.exs:34: (test)



  3) property my_starts_with?/1 (StdlibSamplesTest)
     examples/examples_test.exs:8
     Failed with generated values:
     
       bin1 <- binary()
       #=> ""
     
       bin2 <- binary()
       #=> "u"
     
     Expected truthy, got false
     code: assert my_starts_with?(bin1 <> bin2, bin1)
     stacktrace:
       examples/examples_test.exs:11: anonymous fn/3 in StdlibSamplesTest."property my_starts_with?/1"/1
       (stream_data) lib/stream_data.ex:1420: StreamData.check_all/6
       examples/examples_test.exs:9: (test)



  4) property element not in list (with options) (StdlibSamplesTest)
     examples/examples_test.exs:15
     Failed with generated values:
     
       list <- list_of(int())
       #=> [22]
     
     Expected truthy, got false
     code: assert 22 not in list
     stacktrace:
       examples/examples_test.exs:19: anonymous fn/2 in StdlibSamplesTest."property element not in list (with options)"/1
       (stream_data) lib/stream_data.ex:1454: StreamData.shrink_failure/6
       (stream_data) lib/stream_data.ex:1424: StreamData.check_all/6
       examples/examples_test.exs:16: (test)



Finished in 0.1 seconds (0.1s on load, 0.02s on tests)
3 properties, 1 test, 4 failures
```

</details>

@josevalim questions:

1. now there's no clear place where we can say how many nodes we visited because we don't always show the shrunk error
2. I am not sure it's good to not show the shrinking because it's so nice to see what the original error was and what it became after shrinking :P

Thoughts?