### PR TITLE
fail_eventually

### DIFF
--- a/test/ex_unit_properties_test.exs
+++ b/test/ex_unit_properties_test.exs
@@ -111,4 +111,52 @@ defmodule ExUnitPropertiesTest do
       end
     end
   end
+
+  describe "fail_eventually" do
+
+    # test fail_eventually
+    property "all integers are positive" do
+      fail_eventually do
+        check all n <- integer() do
+          assert n >= 0
+        end
+      end
+    end
+
+    # test fail_eventually
+    property "all lists have a head" do
+      fail_eventually do
+        check all l <- list_of(positive_integer()) do
+          assert length(l) >= 0
+          n = hd(l)
+          assert n >= 0
+        end
+      end
+    end
+
+    # test fail_eventually will fail, because nothing fails inside
+    property "all non negative integers are positive" do
+      assert_raise(ExUnitProperties.NoGeneratedDataWithFailuresError, fn ->
+        fail_eventually do
+          check all n <- positive_integer() do
+            assert n >= 0
+          end
+        end
+      end)
+    end
+
+    # test fail_eventually, because nothing fails inside
+    property "all nonempty lists have a head" do
+      assert_raise(ExUnitProperties.NoGeneratedDataWithFailuresError, fn ->
+        fail_eventually do
+          check all l <- nonempty(list_of(positive_integer())) do
+            assert length(l) >= 0
+            n = hd(l)
+            assert n >= 0
+          end
+        end
+      end)
+    end
+
+  end
 end


### PR DESCRIPTION
The `fail_eventually` macro allows to state properties that are expected to eventually fail.

The `check all` macro is essentially an universal quantifier (for all x in X the following holds..), `fail_eventually` is its existential counterpart: there is some x in X for that following does not hold. It wraps a `check all` property and test whether that property fails. If yes, then everything is ok, otherwise it fails. 

Technically, the same can be achieved by wrapping the `check all` macro with an `assert_raise`, as already done in the tests. But this depends on the internals of `check all` and we need to catch two exceptions: `ExUnitProperties.Error` and `ExUnit.AssertionError`.  With `fail_eventually` the programmer can express her intention more clearly and there is no need to negate the property.
