### PR TITLE
Improve docs

### DIFF
--- a/lib/ex_unit_properties.ex
+++ b/lib/ex_unit_properties.ex
@@ -104,7 +104,7 @@ defmodule ExUnitProperties do
   end
 
   @doc """
-  Setus up an ex unit case module for property testing.
+  Setus up an `ExUnit.Case` module for property-based testing.
   """
   defmacro __using__(_opts) do
     quote do

--- a/lib/ex_unit_properties.ex
+++ b/lib/ex_unit_properties.ex
@@ -104,7 +104,7 @@ defmodule ExUnitProperties do
   end
 
   @doc """
-  Setus up an `ExUnit.Case` module for property-based testing.
+  Sets up an `ExUnit.Case` module for property-based testing.
   """
   defmacro __using__(_opts) do
     quote do

--- a/lib/ex_unit_properties.ex
+++ b/lib/ex_unit_properties.ex
@@ -103,7 +103,9 @@ defmodule ExUnitProperties do
     defexception [:message]
   end
 
-  @doc false
+  @doc """
+  Setus up an ex unit case module for property testing.
+  """
   defmacro __using__(_opts) do
     quote do
       import unquote(__MODULE__)

--- a/lib/stream_data.ex
+++ b/lib/stream_data.ex
@@ -1471,7 +1471,7 @@ defmodule StreamData do
     map(power_of_two_with_zero(abs_exp), &(&1 * factor))
   end
 
-  def power_of_two_with_zero(abs_exp) do
+  defp power_of_two_with_zero(abs_exp) do
     new(fn seed, _size ->
       integer = uniform_in_range(0..power_of_two(abs_exp), seed)
       powers = Stream.map(abs_exp..0, &lazy_tree_constant(power_of_two(&1)))


### PR DESCRIPTION
* make `ExUnitProperties.__using__` not private - otherwise there's no way
to know if it use should or should not be called by users
* make the power_of_two_with_zero function private