### PR TITLE
Add `max_run_time` configuration option

### DIFF
--- a/lib/ex_unit_properties.ex
+++ b/lib/ex_unit_properties.ex
@@ -327,9 +327,9 @@ defmodule ExUnitProperties do
     * `:max_runs` - (non-negative integer) the total number of generations to
       run. Defaults to `100`.
 
-    * `:max_run_time` - (non-negative integer) the total number of time in milliseconds
-      to run a given property check for. This is not used by default, so unless a value
-      is given, then the length of the test will be determined by `:max_runs`.
+    * `:max_run_time` - (non-negative integer) the total number of time (in milliseconds)
+      to run a given check for. This is not used by default, so unless a value
+      is given then the length of the test will be determined by `:max_runs`.
       If both `:max_runs` and `:max_run_time` are given, then the check will finish at
       whichever comes first, `:max_runs` or `:max_run_time`.
 

--- a/lib/ex_unit_properties.ex
+++ b/lib/ex_unit_properties.ex
@@ -327,6 +327,12 @@ defmodule ExUnitProperties do
     * `:max_runs` - (non-negative integer) the total number of generations to
       run. Defaults to `100`.
 
+    * `:max_run_time` - (non-negative integer) the total number of time in milliseconds
+      to run a given property check for. This is not used by default, so unless a value
+      is given, then the length of the test will be determined by `:max_runs`.
+      If both `:max_runs` and `:max_run_time` are given, then the check will finish at
+      whichever comes first, `:max_runs` or `:max_run_time`.
+
     * `:max_shrinking_steps` - (non-negative integer) the maximum numbers of
       shrinking steps to perform in case a failing case is found. Defaults to
       `100`.
@@ -379,6 +385,8 @@ defmodule ExUnitProperties do
         initial_size:
           options[:initial_size] || Application.fetch_env!(:stream_data, :initial_size),
         max_runs: options[:max_runs] || Application.fetch_env!(:stream_data, :max_runs),
+        max_run_time:
+          options[:max_run_time] || Application.fetch_env!(:stream_data, :max_run_time),
         max_shrinking_steps:
           options[:max_shrinking_steps] ||
             Application.fetch_env!(:stream_data, :max_shrinking_steps)

--- a/lib/stream_data.ex
+++ b/lib/stream_data.ex
@@ -181,6 +181,14 @@ defmodule StreamData do
     end
   end
 
+  defmodule InfiniteLoopError do
+    defexception message: """
+    You have attempted to set the `max_runs` and `max_run_time` settings both to
+    `:infinity`, which will result in an infinte loop. Please be sure to set at least
+    one of these settings to avoid this error.
+    """
+  end
+
   ### Minimal interface
 
   ## Helpers
@@ -1935,10 +1943,13 @@ defmodule StreamData do
 
     config =
       case {Keyword.get(options, :max_runs), Keyword.get(options, :max_run_time, :infinity)} do
+        {:infinity, :infinity} ->
+          raise StreamData.InfiniteLoopError
+
         {max_runs, :infinity} ->
           Map.put(config, :max_runs, max_runs || 100)
 
-        {nil, max_run_time} ->
+        {:infinity, max_run_time} ->
           Map.put(config, :max_run_time, start_time + max_run_time)
 
         {max_runs, max_run_time} ->

--- a/lib/stream_data.ex
+++ b/lib/stream_data.ex
@@ -1881,6 +1881,12 @@ defmodule StreamData do
     * `:max_runs` - (non-negative integer) the total number of elements to
       generate out of `data` and check through `fun`. Defaults to `100`.
 
+    * `:max_run_time` - (non-negative integer) the total number of time in milliseconds
+      to run a given property check for. This is not used by default, so unless a value
+      is given, then the length of the test will be determined by `:max_runs`.
+      If both `:max_runs` and `:max_run_time` are given, then the check will finish at
+      whichever comes first, `:max_runs` or `:max_run_time`.
+
     * `:max_shrinking_steps` - (non-negative integer) the maximum numbers of
       shrinking steps to perform in case `check_all/3` finds an element that
       doesn't satisfy `fun`. Defaults to `100`.
@@ -1924,27 +1930,28 @@ defmodule StreamData do
     seed = new_seed(Keyword.fetch!(options, :initial_seed))
     size = Keyword.get(options, :initial_size, 1)
     max_shrinking_steps = Keyword.get(options, :max_shrinking_steps, 100)
-    max_runs = Keyword.get(options, :max_runs, 100)
+    max_runs = Keyword.get(options, :max_runs, :not_set)
+    max_run_time = Keyword.get(options, :max_run_time, :infinity)
+    config = generate_config(max_runs, max_shrinking_steps, max_run_time)
 
-    config = %{
-      max_runs: max_runs,
-      max_shrinking_steps: max_shrinking_steps
-    }
-
-    check_all(data, seed, size, fun, _runs = 0, config)
+    check_all(data, seed, size, fun, _runs = 0, System.system_time(:millisecond), config)
   end
 
-  defp check_all(_data, _seed, _size, _fun, runs, %{max_runs: runs}) do
+  defp check_all(_data, _seed, _size, _fun, _runs, current_time, %{max_run_time: end_time}) when current_time >= end_time do
     {:ok, %{}}
   end
 
-  defp check_all(data, seed, size, fun, runs, config) do
+  defp check_all(_data, _seed, _size, _fun, runs, _current_time, %{max_runs: runs}) do
+    {:ok, %{}}
+  end
+
+  defp check_all(data, seed, size, fun, runs, _current_time, config) do
     {seed1, seed2} = split_seed(seed)
     %LazyTree{root: root, children: children} = call(data, seed1, size)
 
     case fun.(root) do
       {:ok, _term} ->
-        check_all(data, seed2, size + 1, fun, runs + 1, config)
+        check_all(data, seed2, size + 1, fun, runs + 1, System.system_time(:millisecond), config)
 
       {:error, reason} ->
         shrinking_result =
@@ -1954,6 +1961,39 @@ defmodule StreamData do
 
         {:error, shrinking_result}
     end
+  end
+
+  # max_runs and max_run_time both not set by user, default to 100 runs.
+  defp generate_config(:not_set, max_shrinking_steps, :infinity) do
+    %{
+      max_shrinking_steps: max_shrinking_steps,
+      max_runs: 100
+    }
+  end
+
+  # max_runs set by user, max_run_time not set by user. Use just max_runs.
+  defp generate_config(max_runs, max_shrinking_steps, :infinity) do
+    %{
+      max_runs: max_runs,
+      max_shrinking_steps: max_shrinking_steps
+    }
+  end
+
+  # max_run_time set by user, max_runs not set by user. Use just max_run_time.
+  defp generate_config(:not_set, max_shrinking_steps, max_run_time) do
+    %{
+      max_shrinking_steps: max_shrinking_steps,
+      max_run_time: System.system_time(:millisecond) + max_run_time
+    }
+  end
+
+  # max_run_time and max_runs both set by user
+  defp generate_config(max_runs, max_shrinking_steps, max_run_time) do
+    %{
+      max_runs: max_runs,
+      max_shrinking_steps: max_shrinking_steps,
+      max_run_time: System.system_time(:millisecond) + max_run_time
+    }
   end
 
   defp shrink_initial_cont(nodes) do

--- a/mix.exs
+++ b/mix.exs
@@ -36,6 +36,7 @@ defmodule StreamData.Mixfile do
       env: [
         initial_size: 1,
         max_runs: 100,
+        max_run_time: :infinity,
         max_shrinking_steps: 100
       ]
     ]

--- a/test/ex_unit_properties_test.exs
+++ b/test/ex_unit_properties_test.exs
@@ -35,18 +35,20 @@ defmodule ExUnitPropertiesTest do
     end
   end
 
-  property "supports rescue" do
-    raise "some error"
-  rescue
-    exception in [RuntimeError] ->
-      assert Exception.message(exception) == "some error"
-  end
+  describe "error handling" do
+    property "supports rescue" do
+      raise "some error"
+    rescue
+      exception in [RuntimeError] ->
+        assert Exception.message(exception) == "some error"
+    end
 
-  property "supports catch" do
-    throw(:some_error)
-  catch
-    :throw, term ->
-      assert term == :some_error
+    property "supports catch" do
+      throw(:some_error)
+    catch
+      :throw, term ->
+        assert term == :some_error
+    end
   end
 
   describe "check all" do
@@ -70,6 +72,52 @@ defmodule ExUnitPropertiesTest do
       end
 
       assert Agent.get(counter, & &1) == 10
+    end
+
+    property "runs for the specified number of milliseconds" do
+      {:ok, counter} = Agent.start_link(fn -> 0 end)
+
+      # I'm explicitly passing max_runs: :not_set to override the project-wide
+      # config in the `mix.exs` file of `max_runs: 100`.
+      check all :ok <- :ok, max_runs: :not_set, max_run_time: 250 do
+        :timer.sleep(1)
+        Agent.update(counter, &(&1 + 1))
+        :ok
+      end
+
+      total_runs = Agent.get(counter, & &1)
+      # I want to make sure there are more than 100 executions since that's the
+      # default number of runs. Because of variation of runtimes of the other
+      # code in that property, we shouldn't make assertions that are too
+      # specific.
+      assert total_runs > 100
+      assert total_runs < 250
+    end
+
+    property "ends at either max_runs or max_run_time, whichever is first" do
+      {:ok, counter} = Agent.start_link(fn -> 0 end)
+
+      check all :ok <- :ok, max_runs: 5, max_run_time: 100 do
+        :timer.sleep(1)
+        Agent.update(counter, &(&1 + 1))
+        :ok
+      end
+
+      # Because the `max_runs` is less than `max_run_time`, we should only
+      # execute the property test 5 times.
+      assert Agent.get(counter, & &1) == 5
+
+      check all :ok <- :ok, max_runs: 25, max_run_time: 10 do
+        :timer.sleep(1)
+        Agent.update(counter, &(&1 + 1))
+        :ok
+      end
+
+      # Because `max_run_time` is less than `max_runs` in this case because
+      # we're sleeping for 1ms every run, we should stop at that `max_run_time`.
+      total_runs = Agent.get(counter, & &1)
+      assert total_runs > 5
+      assert total_runs <= 15
     end
 
     property "works with errors that are not assertion errors" do


### PR DESCRIPTION
This allows users to set both a `max_runs` option to their property
tests, limiting the tests to a set number of generations, as well as a
`max_run_time` option to ensure that the tests don't take longer than a
certain time period. This is the first rough draft of this feature, and
I'm going to focus more on the documentation and some refactoring in
the next commit after I get a little feedback from folks. As it is now
it's functional, though.

Resolves #69 