### PR TITLE
Add support for `do: body` syntax.

### DIFF
--- a/lib/ex_unit_properties.ex
+++ b/lib/ex_unit_properties.ex
@@ -223,7 +223,8 @@ defmodule ExUnitProperties do
 
   """
   defmacro gen({:all, _meta, clauses_with_body}) do
-    [[do: body] | clauses] = Enum.reverse(clauses_with_body)
+    [[do: body] | reversed_clauses] = Enum.reverse(clauses_with_body)
+    clauses = Enum.reverse(reversed_clauses)
     compile(clauses, body)
   end
 

--- a/lib/ex_unit_properties.ex
+++ b/lib/ex_unit_properties.ex
@@ -374,8 +374,18 @@ defmodule ExUnitProperties do
       end
 
   """
+  defmacro check({:all, _meta, clauses_with_body}) when is_list(clauses_with_body) do
+    [[do: body] | options_and_clauses] = Enum.reverse(clauses_with_body)
+    clauses_and_options = Enum.reverse(options_and_clauses)
+    compile_check_all(clauses_and_options, body)
+  end
+
   defmacro check({:all, _meta, clauses_and_options} = _generation_clauses, [do: body] = _block)
            when is_list(clauses_and_options) do
+    compile_check_all(clauses_and_options, body)
+  end
+
+  defp compile_check_all(clauses_and_options, body) do
     {clauses, options} = split_clauses_and_options(clauses_and_options)
 
     quote do

--- a/lib/ex_unit_properties.ex
+++ b/lib/ex_unit_properties.ex
@@ -222,7 +222,11 @@ defmodule ExUnitProperties do
     * value generation clauses affect shrinking similarly to `bind/2`
 
   """
-  # TODO: support do: syntax
+  defmacro gen({:all, _meta, clauses_with_body}) do
+    [[do: body] | clauses] = Enum.reverse(clauses_with_body)
+    compile(clauses, body)
+  end
+
   defmacro gen({:all, _meta, clauses} = _generation_clauses, [do: body] = _block) do
     compile(clauses, body)
   end

--- a/lib/stream_data.ex
+++ b/lib/stream_data.ex
@@ -2076,8 +2076,10 @@ defmodule StreamData do
     :rand.seed_s(exported_seed)
   end
 
-  @compile {:inline,
-            split_seed: 1, order: 2, uniform_in_range: 3, lazy_tree: 2, lazy_tree_constant: 1}
+  @compile {
+             :inline,
+             split_seed: 1, order: 2, uniform_in_range: 3, lazy_tree: 2, lazy_tree_constant: 1
+           }
 
   defp split_seed(seed) do
     {int, seed} = :rand.uniform_s(1_000_000_000, seed)

--- a/test/ex_unit_properties_test.exs
+++ b/test/ex_unit_properties_test.exs
@@ -151,6 +151,19 @@ defmodule ExUnitPropertiesTest do
         end
       end
     end
+
+    test "supports do keyword syntax" do
+      check all int <- integer(), do: assert(is_integer(int))
+
+      check all a <- binary(),
+                b <- binary(),
+                do: assert(String.starts_with?(a <> b, a))
+
+      check all int1 <- integer(),
+                int2 <- integer(),
+                sum = abs(int1) + abs(int2),
+                do: assert(sum >= int1)
+    end
   end
 
   if Version.compare(System.version(), "1.6.0-dev") in [:eq, :gt] do

--- a/test/ex_unit_properties_test.exs
+++ b/test/ex_unit_properties_test.exs
@@ -33,6 +33,19 @@ defmodule ExUnitPropertiesTest do
         Enum.take(data, 1)
       end
     end
+
+    test "supports do keyword syntax" do
+      gen all _boolean <- boolean(), do: :ok
+
+      data =
+        gen all string <- binary(),
+                list <- list_of(integer()), do: {string, list}
+
+      check all {string, list} <- data do
+        assert is_binary(string)
+        assert is_list(list)
+      end
+    end
   end
 
   describe "property" do

--- a/test/ex_unit_properties_test.exs
+++ b/test/ex_unit_properties_test.exs
@@ -35,11 +35,14 @@ defmodule ExUnitPropertiesTest do
     end
 
     test "supports do keyword syntax" do
-      gen all _boolean <- boolean(), do: :ok
+      gen(all _boolean <- boolean(), do: :ok)
 
       data =
-        gen all string <- binary(),
-                list <- list_of(integer()), do: {string, list}
+        gen(
+          all string <- binary(),
+              list <- list_of(integer()),
+              do: {string, list}
+        )
 
       check all {string, list} <- data do
         assert is_binary(string)


### PR DESCRIPTION
Fixed a small TODO :)
Checking the AST it was of the form:

 ```
 {:gen, _meta,
   [
      {:all, _meta,
        [
          ...clauses...,
          [do: body]
        ]
      }
   ]
 }
```

Decided to just reverse it compile time and get the body.

Wasn't sure how to test it, so added a one clause test that it compiles
and one that the generators are fine since I do a reverse there.

Tell me if I've missed anything, or perhaps should change the docs.