### PR TITLE
Wrong parameter name fix

### DIFF
--- a/lib/stream_data.ex
+++ b/lib/stream_data.ex
@@ -1629,7 +1629,7 @@ defmodule StreamData do
   @doc """
   Generates a string of the given kind or from the given characters.
 
-  `kind_or_chars` can be:
+  `kind_or_codepoints` can be:
 
     * `:ascii` - strings containing only ASCII characters are generated. Such
       strings shrink towards lower codepoints.
@@ -1663,7 +1663,7 @@ defmodule StreamData do
   ## Shrinking
 
   Shrinks towards smaller strings and as described in the description of the
-  possible values of `kind_or_chars` above.
+  possible values of `kind_or_codepoints` above.
   """
   @spec string(:ascii | :alphanumeric | :printable | Range.t() | [Range.t() | pos_integer()]) ::
           t(String.t())


### PR DESCRIPTION
This PR fixes a minor documentation error where it refers to a `kind_of_chars` parameter and in the function is called `find_of_codepoints`.