### PR TITLE
Fix positive_integer crashing for size = 0

### DIFF
--- a/lib/stream_data.ex
+++ b/lib/stream_data.ex
@@ -1441,6 +1441,7 @@ defmodule StreamData do
   @spec positive_integer() :: t(pos_integer())
   def positive_integer() do
     new(fn seed, size ->
+      size = max(size, 1)
       {init, _next_seed} = uniform_in_range(1, size, seed)
       integer_lazy_tree(init, 1, size)
     end)

--- a/test/stream_data_test.exs
+++ b/test/stream_data_test.exs
@@ -230,9 +230,9 @@ defmodule StreamDataTest do
       end
     end
 
-    property "resized to 0" do
-      check all int <- resize(positive_integer(), 0) do
-        assert 1 = int
+    property "works when resized to 0" do
+      check all int <- resize(positive_integer(), 0), max_runs: 3 do
+        assert int == 1
       end
     end
   end

--- a/test/stream_data_test.exs
+++ b/test/stream_data_test.exs
@@ -222,10 +222,18 @@ defmodule StreamDataTest do
     end
   end
 
-  property "positive_integer/0" do
-    check all int <- positive_integer() do
-      assert is_integer(int)
-      assert int in 1..1000
+  describe "positive_integer/0" do
+    property "without bounds" do
+      check all int <- positive_integer() do
+        assert is_integer(int)
+        assert int in 1..1000
+      end
+    end
+
+    property "resized to 0" do
+      check all int <- resize(positive_integer(), 0) do
+        assert 1 = int
+      end
     end
   end
 


### PR DESCRIPTION
My main motivation for this is that I use something like the following to generate a typed expression tree:

```elixir
sized(fn size ->
  frequency([
    {1, leaf(type)},
    {size,  branch(type) |> resize(div(size, 2))}
  ])
end)
```

the size often becomes 0 in the leaves. The other generators seem to handle it well, but `positive_integer` crashes.