### PR TITLE
Pass in options correctly in do keyword syntax.

### DIFF
--- a/lib/ex_unit_properties.ex
+++ b/lib/ex_unit_properties.ex
@@ -413,8 +413,9 @@ defmodule ExUnitProperties do
   """
   defmacro check({:all, _meta, clauses_with_body} = _clauses_and_body)
            when is_list(clauses_with_body) do
-    {clauses_and_options, [[do: body]]} = Enum.split(clauses_with_body, -1)
-    compile_check_all(clauses_and_options, body)
+    {clauses, [body_with_options]} = Enum.split(clauses_with_body, -1)
+    {options, [do: body]} = Enum.split(body_with_options, -1)
+    compile_check_all(clauses ++ [options], body)
   end
 
   # We don't need docs for `check/2`, the docs for `check/1` are enough since

--- a/test/ex_unit_properties_test.exs
+++ b/test/ex_unit_properties_test.exs
@@ -188,7 +188,18 @@ defmodule ExUnitPropertiesTest do
       check all int1 <- integer(),
                 int2 <- integer(),
                 sum = abs(int1) + abs(int2),
+                max_runs: 25,
                 do: assert(sum >= int1)
+    end
+
+    test "do keyword syntax passes in options" do
+      {:ok, counter} = Agent.start_link(fn -> 0 end)
+
+      check all int <- integer(),
+                max_runs: 25,
+                do: Agent.update(counter, &(&1 + 1)) && assert is_integer(int)
+
+      assert Agent.get(counter, & &1) == 25
     end
 
     test "errors out if the first clause is not a generator" do

--- a/test/ex_unit_properties_test.exs
+++ b/test/ex_unit_properties_test.exs
@@ -197,7 +197,7 @@ defmodule ExUnitPropertiesTest do
 
       check all int <- integer(),
                 max_runs: 25,
-                do: Agent.update(counter, &(&1 + 1)) && assert is_integer(int)
+                do: Agent.update(counter, &(&1 + 1)) && assert(is_integer(int))
 
       assert Agent.get(counter, & &1) == 25
     end


### PR DESCRIPTION
Doing a:
  `check all i <- integer(), max_runs: 25, do: assert ...`

failed with a match error because the options were packed with the body.

Fixed by extracting the options for a second time with `&Enum.split/2`.
Match on the body again to make sure that people don't pass in options
after the body.
Pack the options in another list since compile_check_all expects them
that way.

Added a test with a counter to verify this behaviour.