### PR TITLE
Fixed example in docs for fixed_map/1

### DIFF
--- a/lib/stream_data.ex
+++ b/lib/stream_data.ex
@@ -1200,7 +1200,7 @@ defmodule StreamData do
         binary: StreamData.binary(),
       })
       Enum.take(data, 3)
-      #=> [%{binary: "", int: 1}, %{binary: "", int: -2}, %{binary: "R1^", int: -3}]
+      #=> [%{binary: "", integer: 1}, %{binary: "", integer: -2}, %{binary: "R1^", integer: -3}]
 
   ## Shrinking
 


### PR DESCRIPTION
In the docs for `fixed_map`, the `:int` key in the example result should be `:integer`. 