### PR TITLE
Parallel properties

### DIFF
--- a/lib/ex_unit_properties.ex
+++ b/lib/ex_unit_properties.ex
@@ -445,7 +445,8 @@ defmodule ExUnitProperties do
           options[:max_run_time] || Application.fetch_env!(:stream_data, :max_run_time),
         max_shrinking_steps:
           options[:max_shrinking_steps] ||
-            Application.fetch_env!(:stream_data, :max_shrinking_steps)
+            Application.fetch_env!(:stream_data, :max_shrinking_steps),
+        parallel: options[:parallel] || false
       ]
 
       property =

--- a/test/stream_data_test.exs
+++ b/test/stream_data_test.exs
@@ -601,7 +601,7 @@ defmodule StreamDataTest do
     assert is_list(info.original_failure) and 5 in info.original_failure
     assert info.shrunk_failure == [5]
     assert is_integer(info.nodes_visited) and info.nodes_visited >= 0
-    assert is_integer(info.successful_runs) and info.successful_runs >= 0
+    assert is_integer(info.successful_runs) and info.successful_runs > 0
 
     assert check_all(list_of(boolean()), options, property) == {:ok, %{}}
   end


### PR DESCRIPTION
Related to #106.

@josevalim opening this mostly to get your feedback. To make parallel properties work, I had to change `check_all` to create an enumerable that returns lazy trees so that we can do map or async_stream on it, depending on `:parallel`. The main problem is that while this works, I think in many many cases it will make things much slower because of all the processes that are created. This is really only useful if the heavy work you do is in the `do`/`end` block you pass to `check all` as it won't make generating happen in parallel. THoughts? Does it make the code too complex and it's not worth it?