### PR TITLE
Typespec fixes, fix #130

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ elixir: '1.9'
 jobs:
   - check formatted
   - test
+  - check typespecs
 
 script:
   - mix test --include stdlib
@@ -28,3 +29,10 @@ jobs:
 
     - stage: check formatted
       script: mix format --check-formatted
+
+    - stage: check typespecs
+      script: MIX_ENV=dev mix do clean, compile, dialyzer --halt-exit-status
+
+cache:
+  directories:
+  - _build/dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,6 @@ jobs:
   include:
     - stage: test
 
-    - otp_release: '18.3'
-      elixir: '1.5'
-
     - otp_release: '19.3'
       elixir: '1.6'
 

--- a/lib/stream_data.ex
+++ b/lib/stream_data.ex
@@ -107,10 +107,10 @@ defmodule StreamData do
   @typep generator_fun(a) :: (seed(), size() -> LazyTree.t(a))
 
   @typedoc """
-  An opaque type that represents a `StreamData` generator that generates values
+  A type that represents a `StreamData` generator that generates values
   of type `a`.
   """
-  @opaque t(a) :: %__MODULE__{generator: generator_fun(a)} | atom() | tuple()
+  @type t(a) :: %__MODULE__{generator: generator_fun(a)} | atom() | tuple()
 
   # TODO: remove once we depend on OTP 20+ since :exs64 is deprecated.
   if String.to_integer(System.otp_release()) >= 20 do

--- a/lib/stream_data.ex
+++ b/lib/stream_data.ex
@@ -340,9 +340,12 @@ defmodule StreamData do
   This generator shrinks like `bind/2` but values that are skipped are not used
   for shrinking (similarly to how `filter/3` works).
   """
-  @spec bind_filter(input(a), (a -> {:cont, t(b)} | :skip), non_neg_integer()) :: t(b)
-        when a: term(),
-             b: term()
+  @spec bind_filter(
+          input(a),
+          (a -> {:cont, t(b)} | :skip) | (a, non_neg_integer() -> {:cont, t(b)} | :skip),
+          non_neg_integer()
+        ) :: t(b)
+        when a: term(), b: term()
   def bind_filter(data, fun, max_consecutive_failures \\ 10)
 
   def bind_filter(data, fun, max_consecutive_failures) when is_function(fun, 1) do

--- a/mix.exs
+++ b/mix.exs
@@ -11,6 +11,7 @@ defmodule StreamData.Mixfile do
       elixir: "~> 1.5",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
+      dialyzer: dialyzer(),
 
       # Docs
       name: "StreamData",
@@ -44,7 +45,24 @@ defmodule StreamData.Mixfile do
 
   defp deps() do
     [
-      {:ex_doc, "~> 0.19", only: :dev}
+      {:ex_doc, "~> 0.19", only: :dev},
+      {:dialyxir, "~> 1.0.0-rc.6", only: [:dev, :test], runtime: false}
+    ]
+  end
+
+  defp dialyzer() do
+    [
+      plt_add_deps: :apps_direct,
+      plt_add_apps: ~w(
+        ex_unit
+        mix
+      )a,
+      flags: ~w(
+        error_handling
+        race_conditions
+        unmatched_returns
+        underspecs
+      )a
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,7 @@
 %{
+  "dialyxir": {:hex, :dialyxir, "1.0.0-rc.6", "78e97d9c0ff1b5521dd68041193891aebebce52fc3b93463c0a6806874557d7d", [:mix], [{:erlex, "~> 0.2.1", [hex: :erlex, repo: "hexpm", optional: false]}], "hexpm"},
   "earmark": {:hex, :earmark, "1.3.2", "b840562ea3d67795ffbb5bd88940b1bed0ed9fa32834915125ea7d02e35888a5", [:mix], [], "hexpm"},
+  "erlex": {:hex, :erlex, "0.2.2", "cb0e6878fdf86dc63509eaf2233a71fa73fc383c8362c8ff8e8b6f0c2bb7017c", [:mix], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.20.2", "1bd0dfb0304bade58beb77f20f21ee3558cc3c753743ae0ddbb0fd7ba2912331", [:mix], [{:earmark, "~> 1.3", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.10", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
   "makeup": {:hex, :makeup, "0.8.0", "9cf32aea71c7fe0a4b2e9246c2c4978f9070257e5c9ce6d4a28ec450a839b55f", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
   "makeup_elixir": {:hex, :makeup_elixir, "0.13.0", "be7a477997dcac2e48a9d695ec730b2d22418292675c75aa2d34ba0909dcdeda", [:mix], [{:makeup, "~> 0.8", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},


### PR DESCRIPTION
About changing `@opaque` for `@type`, not really sure if this should change, but it fixes the following dialyzer error:
`{:warn_contract_types, {'lib/ex_unit_properties.ex', 605}, {:invalid_contract, [ExUnitProperties, :pick, 1, '(atom() | tuple() | \#{\'__struct__\':=\'Elixir.StreamData\', \'generator\':=fun((_,_) -> any()), _=>_}) -> any()']}}`

This still doesn't fix https://github.com/whatyouhide/stream_data/issues/130 's `no return`, but I have one less error related to stream_data, the following one is gone from [my project](https://github.com/rodrigues/deli/blob/master/test/support/stream_generators.ex):

```
test/support/stream_generators.ex:38:call_without_opaque
Function call without opaqueness type mismatch.

Call does not have expected opaque term of type StreamData.t(_) in the 1st position.

StreamData.nonempty(%StreamData{:generator => (_, _ -> map())})
```

EDIT: other commits were added to this PR, and it now fixes #130. More about it in the following comment.