### PR TITLE
Fixed typo in docs of list_of

### DIFF
--- a/lib/stream_data.ex
+++ b/lib/stream_data.ex
@@ -824,7 +824,7 @@ defmodule StreamData do
   ## Examples
 
       Enum.take(StreamData.list_of(StreamData.binary()), 3)
-      #=> [[""], [], ["", "w"]
+      #=> [[""], [], ["", "w"]]
 
       Enum.take(StreamData.list_of(StreamData.integer(), length: 3), 3)
       #=> [[0, 0, -1], [2, -1, 1], [0, 3, -3]]


### PR DESCRIPTION
Added a closing square bracket to an unclosed list in one of the examples in the docs of `list_of`