### PR TITLE
consider max_length when generating atoms from strings in documentation

### DIFF
--- a/lib/stream_data.ex
+++ b/lib/stream_data.ex
@@ -1802,7 +1802,14 @@ defmodule StreamData do
   need completely arbitrary atoms, you can use a combination of `map/2`, `String.to_atom/1`,
   and string-focused generators to transform arbitrary strings into atoms:
 
-      printable_atom = StreamData.map(StreamData.string(:printable), &String.to_atom/1)
+      printable_atom =
+        StreamData.map(
+          StreamData.string(:printable, max_length: 255),
+          &String.to_atom/1
+        )
+
+  Bear in mind the [system limit](http://erlang.org/doc/efficiency_guide/advanced.html#system-limits)
+  of 255 characters in an atom when doing so.
 
   ## Examples
 


### PR DESCRIPTION
Change the example in `StreamData.atom/1` documentation to take into account the maximum characters in an atom [system limit](http://erlang.org/doc/efficiency_guide/advanced.html#system-limits) when generating atoms from strings.

In particular, change the example
```elixir
printable_atom = StreamData.map(StreamData.string(:printable), &String.to_atom/1)
```
which could — and would, given large enough `max_runs` and/or `mix test` runs — result in something like the following
```
== Compilation error in file test/foo_test.exs ==
** (SystemLimitError) a system limit has been reached
    :erlang.binary_to_atom("攴󝏏ꬼ󗍊𝡲񲆥𷆆𲿹򠛉򒵉􇱃򎓠𦰫𠳸񥣨𢱜󝑈틠󰤰󲚰񿂀񋘹󦍚🻨񜼨񏞑󑮱񪭣򳻖񍍔󉰖󪟭򋱦񸽾򒯜𯖌󝽧󼋘񇌏󞿝򛎉򑞔𐎘󤁠񹂕򔨁󉺐񞤤󜀬񂾾򡕱􅌩󘃘򜪊󵏴󿑢򮯗򒎬𔅹􏬖񑿷񋻅󁤕򦕄󳐙񈆊𳬗󇏬񿀒􁇾񴋆񔩀򡐺㖩򏔿󌰠뻏殈􉟶쏟򶐚򦥄񩨰򆊹𴒹󣹛𱰹򿉁𬌑񸑞󾍐𐻕𕸧󺡽𫄾񒬌󡡴񹛻𤳣𶌏񲔞򍬨𙜲󾙵󳅅􇆳ࢦ𐎂򖴎񪫩񃥹򥜾򺏙󗋗󐵱򼪙򓄠򈴌򸮔򀒮􁁘󝀧󾙵񕅫򓩶򴛹񬨟󅛋񑔓򉟦𭸪쿜󶳺򋕲񘸅𨡯⟞󒲅򹐯󏗑𯚙󣳴𴒶񊢼Ⴥ񲙈󑘗𶧶󷷿򟻕񧳑񣌖􅥛򪂣񊸒򈕬𧗺𩁨򚢊򈹛񎗵񿢘󊈵񭹣񋢗󟸫򭉔𳽂󸵥風𥠈󟆷󾛧󂉪򧈆󁀁󕐄𐯶󵳖󗮜񗭹򱹳𽈁񞹪󫖪򳮔򖨰񤙍💵󡐌󟖝񲖺򍮔󗲻񍅌󭚠󜣎򈎽󲅏򆾱㾠򞔤􀤾󄭵왈񘃘񲏒󄰣󗩻󏏖󙬀򚡄򻒫󗈈𲈘󃶇򜉪󙥐󋧏󮛬𜚡󕊳𦖉󷆍󫹌񵘆򲡯񫙇𗠔򺱓񈺀󮢂񴋋󬝯񇒋񅍫񛶄󗟏鿛➪󉻱𜧻퍎񳤃򭨒󫰫𮙳𜬻󅲙􄽰񁸙􋔜𪬚򟓗񩼲񻈉󜼂𒛷󪨙񬰦󹧐󉾦򭳾򀖈", :utf8)
```
to the safer alternative
```elixir
printable_atom =
  StreamData.map(
    StreamData.string(:printable, max_length: 255),
    &String.to_atom/1
  )
```