### PR TITLE
Fix typo in the docs for optional_map

### DIFF
--- a/lib/stream_data.ex
+++ b/lib/stream_data.ex
@@ -1264,7 +1264,7 @@ defmodule StreamData do
         binary: StreamData.binary(),
       })
       Enum.take(data, 3)
-      #=> [%{binary: "", int: 1}, %{int: -2}, %{binary: "R1^"}]
+      #=> [%{binary: "", integer: 1}, %{integer: -2}, %{binary: "R1^"}]
 
   ## Shrinking
 


### PR DESCRIPTION
Fixed the key in the example result to match the parameters within the example.