### PR TITLE
add-collect-option

### DIFF
--- a/test/ex_unit_properties_test.exs
+++ b/test/ex_unit_properties_test.exs
@@ -1,6 +1,7 @@
 defmodule ExUnitPropertiesTest do
   use ExUnit.Case
   use ExUnitProperties
+  import ExUnit.CaptureIO
 
   describe "gen all" do
     test "supports generation and filtering clauses" do
@@ -268,6 +269,17 @@ defmodule ExUnitPropertiesTest do
           end
         )
       end
+    end
+
+    property "prints distribution data for :collect option" do
+      log =
+        capture_io(fn ->
+          check all b <- boolean(), [collect: :b] do
+            assert is_boolean(b)
+          end
+        end)
+
+      assert log =~ "Collect"
     end
   end
 


### PR DESCRIPTION
Experiment to add new `:collect` option which will print the distribution of values produced by a generator.  This is inspired by the [`collect/2` and `aggregate/2` functions in PropEr](https://proper-testing.github.io/apidocs/proper.html#collect-2).

This is just a first attempt as an experiment to see if it was possible.  Do you folks think something like this would be useful?  It is probably the feature I miss the most from PropEr.  I am completely open to changing the interface, the output, etc.  This is just meant to get a discussion going.

---

Example test 1:

```
property "collect test 1" do
  check all b <- boolean(), [collect: :b] do
    assert is_boolean(b)
  end
end
```

Output
```
$ stream_data git:(add-collect-option) mix test test/ex_unit_properties_test.exs:285
Excluding tags: [:test]
Including tags: [line: "285"]

Collect:
    45.0% true
    55.0% false

.

Finished in 1.0 seconds
11 properties, 12 tests, 0 failures, 22 excluded

Randomized with seed 577891
```

---

Example test 2

```
property "collect test 2" do
  to_range = fn (i) ->
    base = div(i, 10)
    {base * 10, (base + 1) * 10}
  end

  check all i <- integer(0..100), [collect: {:i, to_range}] do
    assert is_integer(i)
  end
end
```

Output
```
$ stream_data git:(add-collect-option) ✗ mix test test/ex_unit_properties_test.exs:285
Excluding tags: [:test]
Including tags: [line: "285"]

Collect:
    15.0% {40, 50}
    15.0% {60, 70}
    15.0% {70, 80}
    10.0% {0, 10}
    10.0% {80, 90}
    9.0% {20, 30}
    8.0% {50, 60}
    7.0% {10, 20}
    6.0% {90, 100}
    5.0% {30, 40}

.

Finished in 1.0 seconds
11 properties, 12 tests, 0 failures, 22 excluded

Randomized with seed 827184
```