### PR TITLE
Replace setup-elixir with setup-beam

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v2.3.1
 
       - name: Install OTP and Elixir
-        uses: actions/setup-elixir@v1
+        uses: erlef/setup-beam@v1
         with:
           otp-version: 23.0
           elixir-version: 1.11.2
@@ -57,7 +57,7 @@ jobs:
       - uses: actions/checkout@v1
 
       - name: Install OTP and Elixir
-        uses: actions/setup-elixir@v1
+        uses: erlef/setup-beam@v1
         with:
           otp-version: ${{matrix.otp}}
           elixir-version: ${{matrix.elixir}}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,24 +31,24 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - otp: 23.0
-            elixir: 1.11.2
+          - otp: 24.0
+            elixir: 1.12.2
             coverage: true
-          - otp: 23.0
-            elixir: 1.10.3
+          - otp: 23.3
+            elixir: 1.12.2
+          - otp: 23.3
+            elixir: 1.11.4
           - otp: 22.3
-            elixir: 1.10.3
-          - otp: 22.1
+            elixir: 1.10.4
+          - otp: 22.3
             elixir: 1.9.4
-          - otp: 21.3
+          - otp: 22.3
             elixir: 1.8.2
+          - otp: 22.3
+            elixir: 1.7.4
           - otp: 20.3
-            elixir: 1.7.4
-          - otp: 19.3
-            elixir: 1.7.4
-          - otp: 19.3
             elixir: 1.6.6
-          - otp: 18.3
+          - otp: 20.3
             elixir: 1.5.3
     env:
       GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
[setup-elixir](https://github.com/actions/setup-elixir) is unmaintained and it's now maintained at [setup-beam](https://github.com/erlef/setup-beam).

This PR replaces `setup-elixir` with `setup-beam` and change version matrix for test(adds OPT 24 and elixir 1.12.2 & removes OTP 19 because `setup-beam` support OTP >= 20 on ubuntu-latest).