### PR TITLE
Implementation of `StreamData.non_negative_integer/0` generator

### DIFF
--- a/lib/stream_data.ex
+++ b/lib/stream_data.ex
@@ -1514,6 +1514,27 @@ defmodule StreamData do
   end
 
   @doc """
+  Generates non-negative integers bound by the generation size.
+
+  ## Examples
+
+  Enum.take(StreamData.non_negative_integer(), 3)
+  #=> [0, 2, 0]
+
+  ## Shrinking
+
+  Generated values shrink towards `0`.
+  """
+  @spec non_negative_integer() :: t(non_neg_integer())
+  def non_negative_integer() do
+    new(fn seed, size ->
+      size = max(size, 0)
+      {init, _next_seed} = uniform_in_range(0, size, seed)
+      integer_lazy_tree(init, 1, size)
+    end)
+  end
+
+  @doc """
   Generates floats according to the given `options`.
 
   The complexity of the generated floats grows proportionally to the generation size.

--- a/lib/stream_data.ex
+++ b/lib/stream_data.ex
@@ -1530,7 +1530,7 @@ defmodule StreamData do
     new(fn seed, size ->
       size = max(size, 0)
       {init, _next_seed} = uniform_in_range(0, size, seed)
-      integer_lazy_tree(init, 1, size)
+      integer_lazy_tree(init, 0, size)
     end)
   end
 

--- a/test/stream_data_test.exs
+++ b/test/stream_data_test.exs
@@ -242,6 +242,21 @@ defmodule StreamDataTest do
     end
   end
 
+  describe "non_negative_integer/0" do
+    property "without bounds" do
+      check all int <- non_negative_integer() do
+        assert is_integer(int)
+        assert int in 0..1000
+      end
+    end
+
+    property "works when resized to 0" do
+      check all int <- resize(non_negative_integer(), 0), max_runs: 3 do
+        assert int == 0
+      end
+    end
+  end
+
   describe "float/1" do
     property "without bounds" do
       check all float <- float() do


### PR DESCRIPTION
This PR adds `StreamData.non_negative_integer()` which is a rather common type to be e.g. used when generating 'sizes'.

Without it, we either would be limited to a particular maximum (using the `StreamData.integer(0..size)` syntax) or had to resort to hacks which are more verbose and slower `StreamData.integer() |> StreamData.map(&abs/1)`.