### PR TITLE
Add property tests for the standard library's Enum.slide/3

### DIFF
--- a/test/stdlib/enum_test.exs
+++ b/test/stdlib/enum_test.exs
@@ -1,0 +1,77 @@
+defmodule StreamData.EnumTest do
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  @moduletag :stdlib
+
+  describe "Enum.slide/3" do
+    property "handles negative indices" do
+      check all(
+              list <- StreamData.list_of(StreamData.integer(), max_length: 100),
+              {range, insertion_idx} <- slide_spec(list)
+            ) do
+        length = length(list)
+        negative_range = (range.first - length)..(range.last - length)//1
+
+        assert Enum.slide(list, negative_range, insertion_idx) ==
+                 Enum.slide(list, range, insertion_idx)
+      end
+    end
+
+    property "matches behavior for lists, ranges, and sets" do
+      range = 0..31
+      list = Enum.to_list(range)
+      set = MapSet.new(list)
+
+      check all({slide_range, insertion_idx} <- slide_spec(list)) do
+        # As of Elixir 1.13, the map implementation underlying a MapSet
+        # maintains the pairs in order below 32 elements.
+        # If this ever stops being true, we can keep the test for
+        # list vs. range but drop the test for list vs. set.
+        slide = &Enum.slide(&1, slide_range, insertion_idx)
+        assert slide.(list) == slide.(range)
+        assert slide.(list) == slide.(set)
+      end
+    end
+
+    property "matches behavior for lists of pairs and maps" do
+      # As of Elixir 1.13, the map implementation maintains the pairs
+      # in order below 32 elements.
+      # If this ever stops being true, we can drop this test.
+      range = 0..31
+      zipped_list = Enum.zip(range, range)
+      map = Map.new(zipped_list)
+
+      check all({slide_range, insertion_idx} <- slide_spec(zipped_list)) do
+        slide = &Enum.slide(&1, slide_range, insertion_idx)
+        assert slide.(zipped_list) == slide.(map)
+      end
+    end
+
+    # Generator for valid slides on the input list
+    # Generates values of the form:
+    #   {range_to_slide, insertion_idx}
+    # ...such that the two arguments are always valid on the given list.
+    defp slide_spec(list) do
+      max_idx = max(0, length(list) - 1)
+
+      StreamData.bind(StreamData.integer(0..max_idx), fn first ->
+        StreamData.bind(StreamData.integer(first..max_idx), fn last ->
+          allowable_insertion_idxs_at_end =
+            if last < max_idx do
+              [StreamData.integer((last + 1)..max_idx)]
+            else
+              []
+            end
+
+          allowable_insertion_idxs =
+            [StreamData.integer(0..first)] ++ allowable_insertion_idxs_at_end
+
+          StreamData.bind(one_of(allowable_insertion_idxs), fn insertion_idx ->
+            StreamData.constant({first..last, insertion_idx})
+          end)
+        end)
+      end)
+    end
+  end
+end

--- a/test/stdlib/enum_test.exs
+++ b/test/stdlib/enum_test.exs
@@ -13,7 +13,14 @@ defmodule StreamData.EnumTest do
                 {range, insertion_idx} <- slide_spec(list)
               ) do
           length = length(list)
-          negative_range = (range.first - length)..(range.last - length)//1
+
+          # TODO: When we depend on 1.12+, rewrite as:
+          # negative_range = (range.first - length)..(range.last - length)//1
+          negative_range = %Range{
+            first: range.first - length,
+            last: range.last - length,
+            step: 1
+          }
 
           assert Enum.slide(list, negative_range, insertion_idx) ==
                    Enum.slide(list, range, insertion_idx)

--- a/test/stdlib/enum_test.exs
+++ b/test/stdlib/enum_test.exs
@@ -4,74 +4,77 @@ defmodule StreamData.EnumTest do
 
   @moduletag :stdlib
 
-  describe "Enum.slide/3" do
-    property "handles negative indices" do
-      check all(
-              list <- StreamData.list_of(StreamData.integer(), max_length: 100),
-              {range, insertion_idx} <- slide_spec(list)
-            ) do
-        length = length(list)
-        negative_range = (range.first - length)..(range.last - length)//1
+  # TODO: Make this unconditional when we depend on Elixir 1.13+.
+  if function_exported?(Enum, :slide, 3) do
+    describe "Enum.slide/3" do
+      property "handles negative indices" do
+        check all(
+                list <- StreamData.list_of(StreamData.integer(), max_length: 100),
+                {range, insertion_idx} <- slide_spec(list)
+              ) do
+          length = length(list)
+          negative_range = (range.first - length)..(range.last - length)//1
 
-        assert Enum.slide(list, negative_range, insertion_idx) ==
-                 Enum.slide(list, range, insertion_idx)
+          assert Enum.slide(list, negative_range, insertion_idx) ==
+                   Enum.slide(list, range, insertion_idx)
+        end
       end
-    end
 
-    property "matches behavior for lists, ranges, and sets" do
-      range = 0..31
-      list = Enum.to_list(range)
-      set = MapSet.new(list)
+      property "matches behavior for lists, ranges, and sets" do
+        range = 0..31
+        list = Enum.to_list(range)
+        set = MapSet.new(list)
 
-      check all({slide_range, insertion_idx} <- slide_spec(list)) do
-        # As of Elixir 1.13, the map implementation underlying a MapSet
-        # maintains the pairs in order below 32 elements.
-        # If this ever stops being true, we can keep the test for
-        # list vs. range but drop the test for list vs. set.
-        slide = &Enum.slide(&1, slide_range, insertion_idx)
-        assert slide.(list) == slide.(range)
-        assert slide.(list) == slide.(set)
+        check all({slide_range, insertion_idx} <- slide_spec(list)) do
+          # As of Elixir 1.13, the map implementation underlying a MapSet
+          # maintains the pairs in order below 32 elements.
+          # If this ever stops being true, we can keep the test for
+          # list vs. range but drop the test for list vs. set.
+          slide = &Enum.slide(&1, slide_range, insertion_idx)
+          assert slide.(list) == slide.(range)
+          assert slide.(list) == slide.(set)
+        end
       end
-    end
 
-    property "matches behavior for lists of pairs and maps" do
-      # As of Elixir 1.13, the map implementation maintains the pairs
-      # in order below 32 elements.
-      # If this ever stops being true, we can drop this test.
-      range = 0..31
-      zipped_list = Enum.zip(range, range)
-      map = Map.new(zipped_list)
+      property "matches behavior for lists of pairs and maps" do
+        # As of Elixir 1.13, the map implementation maintains the pairs
+        # in order below 32 elements.
+        # If this ever stops being true, we can drop this test.
+        range = 0..31
+        zipped_list = Enum.zip(range, range)
+        map = Map.new(zipped_list)
 
-      check all({slide_range, insertion_idx} <- slide_spec(zipped_list)) do
-        slide = &Enum.slide(&1, slide_range, insertion_idx)
-        assert slide.(zipped_list) == slide.(map)
+        check all({slide_range, insertion_idx} <- slide_spec(zipped_list)) do
+          slide = &Enum.slide(&1, slide_range, insertion_idx)
+          assert slide.(zipped_list) == slide.(map)
+        end
       end
-    end
 
-    # Generator for valid slides on the input list
-    # Generates values of the form:
-    #   {range_to_slide, insertion_idx}
-    # ...such that the two arguments are always valid on the given list.
-    defp slide_spec(list) do
-      max_idx = max(0, length(list) - 1)
+      # Generator for valid slides on the input list
+      # Generates values of the form:
+      #   {range_to_slide, insertion_idx}
+      # ...such that the two arguments are always valid on the given list.
+      defp slide_spec(list) do
+        max_idx = max(0, length(list) - 1)
 
-      StreamData.bind(StreamData.integer(0..max_idx), fn first ->
-        StreamData.bind(StreamData.integer(first..max_idx), fn last ->
-          allowable_insertion_idxs_at_end =
-            if last < max_idx do
-              [StreamData.integer((last + 1)..max_idx)]
-            else
-              []
-            end
+        StreamData.bind(StreamData.integer(0..max_idx), fn first ->
+          StreamData.bind(StreamData.integer(first..max_idx), fn last ->
+            allowable_insertion_idxs_at_end =
+              if last < max_idx do
+                [StreamData.integer((last + 1)..max_idx)]
+              else
+                []
+              end
 
-          allowable_insertion_idxs =
-            [StreamData.integer(0..first)] ++ allowable_insertion_idxs_at_end
+            allowable_insertion_idxs =
+              [StreamData.integer(0..first)] ++ allowable_insertion_idxs_at_end
 
-          StreamData.bind(one_of(allowable_insertion_idxs), fn insertion_idx ->
-            StreamData.constant({first..last, insertion_idx})
+            StreamData.bind(one_of(allowable_insertion_idxs), fn insertion_idx ->
+              StreamData.constant({first..last, insertion_idx})
+            end)
           end)
         end)
-      end)
+      end
     end
   end
 end


### PR DESCRIPTION
These are the property tests I wrote while developing `Enum.slide/3`. Following @whatyouhide's [invitation](https://mobile.twitter.com/whatyouhide/status/1484547725429555200), I thought it'd be nice to have these run daily against the latest version of the standard library. 😄

I don't think the stdlib tests run against every PR to `stream_data`, but [they've passed on my fork](https://github.com/s3cur3/stream_data/runs/4971869806?check_suite_focus=true).