### PR TITLE
Fix nonempty_improper_list_of/2 generator

### DIFF
--- a/lib/stream_data.ex
+++ b/lib/stream_data.ex
@@ -1116,7 +1116,7 @@ defmodule StreamData do
 
       data = StreamData.nonempty_improper_list_of(StreamData.byte(), StreamData.binary())
       Enum.take(data, 3)
-      #=> [["\f"], [56 | <<140, 137>>], [226 | "j"]]
+      #=> [[42], [56 | <<140, 137>>], [226 | "j"]]
 
   ## Shrinking
 

--- a/lib/stream_data.ex
+++ b/lib/stream_data.ex
@@ -1128,12 +1128,9 @@ defmodule StreamData do
         when a: term(),
              b: term()
   def nonempty_improper_list_of(first, improper) do
-    map({list_of(first), improper}, fn
-      {[], ending} ->
-        [ending]
-
+    map({list_of(first, min_length: 1), improper}, fn
       {list, ending} ->
-        List.foldr(list, ending, &[&1 | &2])
+        list ++ ending
     end)
   end
 

--- a/test/stream_data_test.exs
+++ b/test/stream_data_test.exs
@@ -446,6 +446,7 @@ defmodule StreamDataTest do
   property "nonempty_improper_list_of/2" do
     check all list <- nonempty_improper_list_of(integer(), constant("")) do
       assert list != []
+      assert list != [""]
       each_improper_list(list, &assert(is_integer(&1)), &assert(&1 == ""))
     end
   end

--- a/test/stream_data_test.exs
+++ b/test/stream_data_test.exs
@@ -446,7 +446,7 @@ defmodule StreamDataTest do
   property "nonempty_improper_list_of/2" do
     check all list <- nonempty_improper_list_of(integer(), constant("")) do
       assert list != []
-      assert list != [""]
+      refute match?([_], list)
       each_improper_list(list, &assert(is_integer(&1)), &assert(&1 == ""))
     end
   end

--- a/test/stream_data_test.exs
+++ b/test/stream_data_test.exs
@@ -453,6 +453,7 @@ defmodule StreamDataTest do
 
   property "maybe_improper_list_of/2" do
     check all list <- maybe_improper_list_of(integer(), constant("")) do
+      assert list != [""]
       each_improper_list(list, &assert(is_integer(&1)), &assert(&1 == "" or is_integer(&1)))
     end
   end


### PR DESCRIPTION
Ensures `[terminator]` will not be generated anymore by `nonempty_improper_list_of/2`

Fixes #169 