### PR TITLE
Fix dialyzer warnings inside project

### DIFF
--- a/lib/ex_unit_properties.ex
+++ b/lib/ex_unit_properties.ex
@@ -540,6 +540,7 @@ defmodule ExUnitProperties do
     end
   end
 
+  @spec __raise__(term()) :: no_return()
   def __raise__(test_result) do
     %{
       original_failure: original_failure,

--- a/lib/stream_data.ex
+++ b/lib/stream_data.ex
@@ -305,6 +305,10 @@ defmodule StreamData do
   raised. See the documentation for `filter/3` for suggestions on how to avoid
   such errors.
 
+  The function can accept one or two arguments. If a two-argument function is
+  passed, the second argument will be the number of tries left before raising
+  `StreamData.FilterTooNarrowError`.
+
   ## Examples
 
   Say we wanted to create a generator that generates two-element tuples where
@@ -336,7 +340,11 @@ defmodule StreamData do
   This generator shrinks like `bind/2` but values that are skipped are not used
   for shrinking (similarly to how `filter/3` works).
   """
-  @spec bind_filter(t(a), (a -> {:cont, t(b)} | :skip), non_neg_integer()) :: t(b)
+  @spec bind_filter(
+          t(a),
+          (a -> {:cont, t(b)} | :skip) | (a, non_neg_integer() -> {:cont, t(b)} | :skip),
+          non_neg_integer()
+        ) :: t(b)
         when a: term(),
              b: term()
   def bind_filter(data, fun, max_consecutive_failures \\ 10)

--- a/lib/stream_data.ex
+++ b/lib/stream_data.ex
@@ -714,7 +714,7 @@ defmodule StreamData do
 
   By nature, this generator is not shrinkable.
   """
-  @spec repeatedly((arg :: any -> returns)) :: t(returns) when returns: term()
+  @spec repeatedly((() -> returns)) :: t(returns) when returns: term()
   def repeatedly(fun) when is_function(fun, 0) do
     new(fn _seed, _size ->
       %LazyTree{root: fun.()}

--- a/lib/stream_data.ex
+++ b/lib/stream_data.ex
@@ -192,6 +192,7 @@ defmodule StreamData do
   # poor implementation of a protocol (which we don't want to add just for
   # this).
   @doc false
+  @spec __call__(StreamData.t(a), seed(), size()) :: a when a: term()
   def __call__(data, seed, size) do
     call(data, seed, size)
   end

--- a/lib/stream_data.ex
+++ b/lib/stream_data.ex
@@ -943,6 +943,7 @@ defmodule StreamData do
 
   The same as calling `list_of/2` with `[]` as options.
   """
+  @spec list_of(t(a)) :: t([a]) when a: term()
   def list_of(data) do
     new(fn seed, size ->
       {length, next_seed} = uniform_in_range(0, size, seed)
@@ -1952,7 +1953,7 @@ defmodule StreamData do
   Shrinks towards smaller atoms and towards "simpler" letters (like towards only alphabet
   letters).
   """
-
+  @spec atom(:alphanumeric | :alias) :: t(atom())
   def atom(kind)
 
   @unquoted_atom_characters [?a..?z, ?A..?Z, ?0..?9, ?_, ?@]


### PR DESCRIPTION
Hi! This fixes warnings when running dialyzer against the project. Most are self-explanatory.

One that was a bit unintuitive is `ExUnitProperties.pick/1`:

```
lib/ex_unit_properties.ex:635: Invalid type specification for function 'Elixir.ExUnitProperties':pick/1.
 The success typing is 'Elixir.ExUnitProperties':pick(atom() | tuple() | #{'__struct__':='Elixir.StreamData', 'generator':=fun((_,_) -> any()), _=>_}) -> any()
 But the spec is 'Elixir.ExUnitProperties':pick('Elixir.StreamData':t(a)) -> a when a :: term()
 They do not overlap in the 1st argument
```

(this is on Erlang master, with improved errors: https://github.com/erlang/otp/pull/6271)

Dialyzer complains that pick's argument must be an instance of `atom() | tuple() | blabla...` for the function to succeed, and yet the typespec says the first argument is a `StreamData.t(a)`, which has nothing to do with the above in Dialyzer's mind (it's an opaque type, so it could potentially be anything - we can't make assumptions).

Why does Dialyzer think pick's argument has to be that specific type to succeed, and not a `StreamData.t(a)`? It's because pick calls `StreamData.__call__/3`, which lacks a typespec. Dialyzer infers the type of call's arguments by code analysis, giving the `atom() | ...` above. If we tell it via typespec that the argument of call is actually a `StreamData.t(a)`, then it figures out that pick will succeed if passed an argument of that type, and the warning goes away.

A similar problem happens when we call `list_of/1` or `atom/1`, which don't have typespecs, and pass the result to `bind_filter`, which expects the opaque type. I added missing typespecs and now get a clean pass on my app, so this might resolve #130. If there are more errors, I can take a look later.