### PR TITLE
Add :utf8 option to string/1 and add chardata/0

### DIFF
--- a/lib/stream_data.ex
+++ b/lib/stream_data.ex
@@ -1818,6 +1818,10 @@ defmodule StreamData do
   end
 
   @ascii_chars ?\s..?~
+
+  # "UTF-8 prohibits encoding character numbers between U+D800 and U+DFFF"
+  @utf8_chars [0..0xD7FF, 0xE000..0x10FFFF]
+
   @alphanumeric_chars [?a..?z, ?A..?Z, ?0..?9]
   @printable_chars [
     ?\n,
@@ -1850,6 +1854,9 @@ defmodule StreamData do
     * `:printable` - printable strings (`String.printable?/1` returns `true`)
       are generated. Such strings shrink towards lower codepoints.
 
+    * `:utf8` - valid strings (`String.valid?/1` returns `true`)
+      are generated. Such strings shrink towards lower codepoints.
+
     * a range - strings with characters from the range are generated. Such
       strings shrink towards characters that appear earlier in the range.
 
@@ -1874,7 +1881,14 @@ defmodule StreamData do
   Shrinks towards smaller strings and as described in the description of the
   possible values of `kind_or_codepoints` above.
   """
-  @spec string(:ascii | :alphanumeric | :printable | Range.t() | [Range.t() | pos_integer()]) ::
+  @spec string(
+          :ascii
+          | :alphanumeric
+          | :printable
+          | :utf8
+          | Range.t()
+          | [Range.t() | pos_integer()]
+        ) ::
           t(String.t())
   def string(kind_or_codepoints, options \\ [])
 
@@ -1888,6 +1902,10 @@ defmodule StreamData do
 
   def string(:printable, options) do
     string(@printable_chars, options)
+  end
+
+  def string(:utf8, options) do
+    string(@utf8_chars, options)
   end
 
   def string(%Range{} = codepoints_range, options) do

--- a/test/stream_data_test.exs
+++ b/test/stream_data_test.exs
@@ -689,6 +689,12 @@ defmodule StreamDataTest do
     end
   end
 
+  property "chardata/0" do
+    check all chardata <- chardata(), max_runs: 50 do
+      assert IO.chardata_to_string(chardata) |> String.valid?()
+    end
+  end
+
   property "term/0" do
     check all term <- term(), max_runs: 25 do
       assert is_boolean(term) or is_integer(term) or is_float(term) or is_binary(term) or

--- a/test/stream_data_test.exs
+++ b/test/stream_data_test.exs
@@ -648,6 +648,12 @@ defmodule StreamDataTest do
       end
     end
 
+    property "with :utf8" do
+      check all string <- string(:utf8) do
+        assert String.valid?(string)
+      end
+    end
+
     property "with a fixed length" do
       check all string <- string(:alphanumeric, length: 3) do
         assert String.length(string) == 3


### PR DESCRIPTION
As discussed, existing [options](https://hexdocs.pm/stream_data/StreamData.html#string/2) can only generate subsets of valid strings (e.g. `printable`), this PR adds a `:utf8` option generating all of them.

It also adds a `chardata/0` generator, similar to `iodata/0` and relying on the `utf8` generator above.