### PR TITLE
Increase the scale in a test to prevent `FilterTooNarrowError`

### DIFF
--- a/test/ex_unit_properties_test.exs
+++ b/test/ex_unit_properties_test.exs
@@ -16,7 +16,7 @@ defmodule ExUnitPropertiesTest do
 
       # Let's make sure that the minimum size is high enough that our filtered element
       # is not common at all.
-      data = scale(data, &max(&1, 20))
+      data = scale(data, &max(&1, 70))
 
       check all {string, list} <- data do
         assert is_binary(string)


### PR DESCRIPTION
Closes #190.