### PR TITLE
Fix deprecation warning on register_test/4

### DIFF
--- a/lib/ex_unit_properties.ex
+++ b/lib/ex_unit_properties.ex
@@ -220,7 +220,8 @@ defmodule ExUnitProperties do
     contents = Macro.escape(contents, unquote: true)
 
     quote bind_quoted: [context: context, contents: contents, message: message] do
-      name = ExUnit.Case.register_test(__ENV__, :property, message, [:property])
+      %{module: mod, file: file, line: line} = __ENV__
+      name = ExUnit.Case.register_test(mod, file, line, :property, message, [:property])
       def unquote(name)(unquote(context)), do: unquote(contents)
     end
   end


### PR DESCRIPTION
On Elixir's `main` branch, `ExUnit.Properties` emits deprecation warnings on [`ExUnit.Case.register_test/4`](https://hexdocs.pm/ex_unit/1.16.1/ExUnit.Case.html#register_test/4):

<img width="606" alt="Screenshot 2024-02-12 at 13 33 50" src="https://github.com/whatyouhide/stream_data/assets/11598866/e5828d03-0c45-4748-b5aa-ec99f0e3092d">

Since `StreamData` supports Elixir `~> 1.11` and `register_test/6` is `since: "1.10.0"`, we can fix it by replacing`register_test/4` by its [implementation](https://github.com/elixir-lang/elixir/blob/v1.16.1/lib/ex_unit/lib/ex_unit/case.ex#L635).