### PR TITLE
Add an explicit step to a range match

### DIFF
--- a/lib/stream_data.ex
+++ b/lib/stream_data.ex
@@ -963,7 +963,7 @@ defmodule StreamData do
         {:ok, length} when is_integer(length) and length >= 0 ->
           {length, length}
 
-        {:ok, min..max} when min >= 0 and max >= 0 ->
+        {:ok, min..max//_} when min >= 0 and max >= 0 ->
           order(min, max)
 
         {:ok, other} ->

--- a/lib/stream_data.ex
+++ b/lib/stream_data.ex
@@ -963,7 +963,7 @@ defmodule StreamData do
         {:ok, length} when is_integer(length) and length >= 0 ->
           {length, length}
 
-        {:ok, min..max//_} when min >= 0 and max >= 0 ->
+        {:ok, %Range{first: min, last: max}} when min >= 0 and max >= 0 ->
           order(min, max)
 
         {:ok, other} ->


### PR DESCRIPTION
Without this, Elixir 1.17 emits a warning for this line.