### PR TITLE
Fix warning about range step

### DIFF
--- a/lib/stream_data.ex
+++ b/lib/stream_data.ex
@@ -1720,7 +1720,7 @@ defmodule StreamData do
   defp power_of_two_with_zero(abs_exp) do
     new(fn seed, _size ->
       {integer, _} = uniform_in_range(0, power_of_two(abs_exp), seed)
-      powers = Stream.map(abs_exp..0, &lazy_tree_constant(power_of_two(&1)))
+      powers = Stream.map(abs_exp..0//-1, &lazy_tree_constant(power_of_two(&1)))
       lazy_tree(integer, Enum.concat(powers, [lazy_tree_constant(0)]))
     end)
   end


### PR DESCRIPTION
Fixes the following warning:

```
warning: Range.new/2 has a default step of -1, please call Range.new/3 explicitly passing the step of -1 instead
  (stream_data 1.1.1) lib/stream_data.ex:1723: anonymous fn/3 in StreamData.power_of_two_with_zero/1
```