### PR TITLE
Remove check for __STACKTRACE__ support

### DIFF
--- a/lib/ex_unit_properties.ex
+++ b/lib/ex_unit_properties.ex
@@ -516,14 +516,6 @@ defmodule ExUnitProperties do
   defp compile_check_all(clauses_and_options, body) do
     {clauses, options} = split_clauses_and_options(clauses_and_options)
 
-    # TODO: remove when we depend on Elixir ~> 1.7.
-    stacktrace_call =
-      if Version.match?(System.version(), "~> 1.7") do
-        quote do: __STACKTRACE__
-      else
-        quote do: System.stacktrace()
-      end
-
     quote do
       options = unquote(options)
 
@@ -561,7 +553,7 @@ defmodule ExUnitProperties do
               exception ->
                 result = %{
                   exception: exception,
-                  stacktrace: unquote(stacktrace_call),
+                  stacktrace: __STACKTRACE__,
                   generated_values: var!(generated_values, unquote(__MODULE__))
                 }
 


### PR DESCRIPTION
StreamData relies on Elixir 1.12 now, so this code is no longer needed