### PR TITLE
Remove deprecated :exs64

### DIFF
--- a/lib/stream_data.ex
+++ b/lib/stream_data.ex
@@ -112,12 +112,7 @@ defmodule StreamData do
   """
   @opaque t(a) :: %__MODULE__{generator: generator_fun(a)} | atom() | tuple()
 
-  # TODO: remove once we depend on OTP 20+ since :exs64 is deprecated.
-  if String.to_integer(System.otp_release()) >= 20 do
-    @rand_algorithm :exsp
-  else
-    @rand_algorithm :exs64
-  end
+  @rand_algorithm :exsp
 
   defstruct [:generator]
 


### PR DESCRIPTION
The minimum version of Elixir for StreamData is 1.12, which requires OTP 22+