### PR TITLE
Fix block code indent in doc

### DIFF
--- a/lib/stream_data.ex
+++ b/lib/stream_data.ex
@@ -1625,8 +1625,8 @@ defmodule StreamData do
 
   ## Examples
 
-  Enum.take(StreamData.non_negative_integer(), 3)
-  #=> [0, 2, 0]
+      Enum.take(StreamData.non_negative_integer(), 3)
+      #=> [0, 2, 0]
 
   ## Shrinking
 


### PR DESCRIPTION
Before: https://hexdocs.pm/stream_data/StreamData.html#non_negative_integer/0

After:
<img width="588" alt="Screenshot 2024-10-31 at 11 05 00" src="https://github.com/user-attachments/assets/96e446f0-2a35-46f3-a9fe-329c5e625a64">
