### PR TITLE
Remove occurrences of the struct update syntax deprecated in Elixir 1.19

### DIFF
--- a/lib/stream_data.ex
+++ b/lib/stream_data.ex
@@ -693,7 +693,7 @@ defmodule StreamData do
   @spec unshrinkable(t(a)) :: t(a) when a: term()
   def unshrinkable(data) do
     new(fn seed, size ->
-      %LazyTree{call(data, seed, size) | children: []}
+      %{call(data, seed, size) | children: []}
     end)
   end
 

--- a/lib/stream_data/lazy_tree.ex
+++ b/lib/stream_data/lazy_tree.ex
@@ -140,7 +140,7 @@ defmodule StreamData.LazyTree do
         end
       end)
 
-    %__MODULE__{tree | children: children}
+    %{tree | children: children}
   end
 
   @doc """


### PR DESCRIPTION
Compiling `stream_data` with Elixir 1.19.0-rc.0 yields the following warnings:
```
==> stream_data
Compiling 3 files (.ex)
     warning: the struct update syntax is deprecated:

     %StreamData.LazyTree{tree | children: children}

     Instead, prefer to pattern matching on structs when the variable is first defined and use the regular map update syntax instead:

     %{tree | children: children}

     │
 143 │     %__MODULE__{tree | children: children}
     │                ~
     │
     └─ lib/stream_data/lazy_tree.ex:143:16

     warning: the struct update syntax is deprecated:

     %StreamData.LazyTree{call(data, seed, size) | children: []}

     Instead, prefer to pattern matching on structs when the variable is first defined and use the regular map update syntax instead:

     %{call(data, seed, size) | children: []}

     │
 696 │       %LazyTree{call(data, seed, size) | children: []}
     │                ~
     │
     └─ lib/stream_data.ex:696:16

Generated stream_data app
```