### PR TITLE
Date generators

### DIFF
--- a/test/stream_data_test.exs
+++ b/test/stream_data_test.exs
@@ -332,6 +332,53 @@ defmodule StreamDataTest do
     end
   end
 
+  describe "date/0" do
+    property "generates any dates" do
+      check all date <- date() do
+        assert %Date{} = date
+      end
+    end
+  end
+
+  describe "date/1" do
+    property "without options, generates any dates" do
+      check all date <- date([]) do
+        assert %Date{} = date
+      end
+    end
+
+    property "with a :min option, generates dates after it" do
+      check all minimum <- date(),
+                date <- date(min: minimum) do
+        assert Date.compare(date, minimum) in [:eq, :gt]
+      end
+    end
+
+    property "with a :max option, generates dates before it" do
+      check all maximum <- date(),
+                date <- date(max: maximum) do
+        assert Date.compare(date, maximum) in [:lt, :eq]
+      end
+    end
+
+    property "with both a :min and a :max option, generates dates in-between the bounds" do
+      check all minimum <- date(),
+                maximum <- date(min: minimum),
+                date <- date(min: minimum, max: maximum) do
+        assert Enum.member?(Date.range(minimum, maximum), date)
+      end
+    end
+
+    property "with a Date.Range, generates dates in-between the bounds" do
+      check all minimum <- date(),
+                maximum <- date(min: minimum),
+                range = Date.range(minimum, maximum),
+                date <- date(range) do
+        assert Enum.member?(range, date)
+      end
+    end
+  end
+
   property "byte/0" do
     check all value <- byte() do
       assert value in 0..255


### PR DESCRIPTION
This is a reimplementation of the date generators by @Qqwy in #161. As such, it is a (partial) implementation for #129.

The tests and documentation are entirely copy-pasted from his PR, but the actual implementation is entirely new. As noted by @whatyouhide in a comment to the original PR, I've opted to use the new `Date.add` function for most of the cases.

I think the resulting implementation is a bit easier to follow. I have not added Time, DateTime or NaiveDateTime, though I think we could probably do something for those that follow this skeleton.