### PR TITLE
Remove unused require

### DIFF
--- a/lib/stream_data.ex
+++ b/lib/stream_data.ex
@@ -534,7 +534,6 @@ defmodule StreamData do
     end
 
     def integer(%Range{first: left, last: right, step: step} = _range) do
-      require Integer
       lower_stepless = Integer.floor_div(left, step)
       upper_stepless = Integer.floor_div(right, step)
 


### PR DESCRIPTION
Pointed out by the compiler on main:

<img width="572" height="252" alt="Screenshot 2025-10-03 at 7 33 11" src="https://github.com/user-attachments/assets/694aff63-3e5d-4e14-83a2-56c690fdbffc" />

I can't think of a reason why it would be an issue to remove it, but if I missed something, we could add `warn: false` instead.