### PR TITLE
Fix float when min and max are too far apart

### DIFF
--- a/lib/stream_data.ex
+++ b/lib/stream_data.ex
@@ -1753,7 +1753,7 @@ defmodule StreamData do
       exponent_data = integer(0..min(size, 1023))
 
       bind(exponent_data, fn exponent ->
-        map(float_in_0_to_1(exponent), fn float -> float * (max - min) + min end)
+        map(float_in_0_to_1(exponent), fn float -> float * max + min * (1.0 - float) end)
       end)
     end)
   end

--- a/test/stream_data_test.exs
+++ b/test/stream_data_test.exs
@@ -294,6 +294,20 @@ defmodule StreamDataTest do
   end
 
   describe "float/1" do
+    test "generates floats close to system limit" do
+      [min, max] = [-9.0e307, 9.0e307]
+      float = float(min: min, max: max) |> Enum.at(0)
+      assert float >= min and float <= max
+    end
+
+    property "with a large negative :min and :max option" do
+      # The large negative min might cause loss of significance.
+      check all float <- float(min: -9.9e25, max: -1) do
+        assert is_float(float)
+        assert float <= -1
+      end
+    end
+
     property "without bounds" do
       check all float <- float() do
         assert is_float(float)


### PR DESCRIPTION
Rearrange the arithmetic expression such that intermediate values are always within the bounds of floating-point numbers that can be represented by the system.

- Fixes ArithmeticError exception when max - min >= 1.79e308. #224 
- Fixes floats generated outside of [min, max] range when upper/lower limits were lost due to loss of significance. #203 (Test case copied from #219 )